### PR TITLE
ワークフローの同時実行制御

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,13 @@ on:
   schedule:
     - cron: '33 9 * * 6'
 
+# 'concurrency'を使用して、同時に実行できるジョブの数を制限します。
+# この設定により、同じワークフローの複数のジョブが同時に実行されるのを防ぎます。
+# https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,13 @@ on:
   # Actionsタブからワークフローの手動実行を許可します。
   workflow_dispatch:
 
+# 'concurrency'を使用して、同時に実行できるジョブの数を制限します。
+# この設定により、同じワークフローの複数のジョブが同時に実行されるのを防ぎます。
+# https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync-to-hub:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,6 +12,13 @@ on:
 permissions:
   contents: read
 
+# 'concurrency'を使用して、同時に実行できるジョブの数を制限します。
+# この設定により、同じワークフローの複数のジョブが同時に実行されるのを防ぎます。
+# https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
mainブランチで直接ファイルを変更時に同時にワークフローが実行されるのを防ぎます。